### PR TITLE
Remove logging config as it breaks projects one

### DIFF
--- a/luxtronik/__init__.py
+++ b/luxtronik/__init__.py
@@ -7,7 +7,6 @@ from luxtronik.calculations import Calculations
 from luxtronik.parameters import Parameters
 from luxtronik.visibilities import Visibilities
 
-logging.basicConfig(level="WARNING")
 LOGGER = logging.getLogger("Luxtronik")
 
 

--- a/luxtronik/calculations.py
+++ b/luxtronik/calculations.py
@@ -2,7 +2,6 @@ import logging
 
 from luxtronik.datatypes import *
 
-logging.basicConfig(level="WARNING")
 LOGGER = logging.getLogger("Luxtronik.Calculations")
 
 

--- a/luxtronik/parameters.py
+++ b/luxtronik/parameters.py
@@ -2,7 +2,6 @@ import logging
 
 from luxtronik.datatypes import *
 
-logging.basicConfig(level="WARNING")
 LOGGER = logging.getLogger("Luxtronik.Parameters")
 
 

--- a/luxtronik/visibilities.py
+++ b/luxtronik/visibilities.py
@@ -2,7 +2,6 @@ import logging
 
 from luxtronik.datatypes import Unknown
 
-logging.basicConfig(level="WARNING")
 LOGGER = logging.getLogger("Luxtronik.Visibilities")
 
 


### PR DESCRIPTION
Having `logging.basicConfig()` in a library will break ones own config if the library is imported before owns config.