### PR TITLE
Add pylint as GitHub action to increase code quality and consistency

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/luxtronik/__init__.py
+++ b/luxtronik/__init__.py
@@ -72,9 +72,9 @@ class Luxtronik:
         for _ in range(0, length):
             try:
                 data.append(struct.unpack(">i", self._socket.recv(4))[0])
-            except struct.error as e:
+            except struct.error as err:
                 # not logging this as error as it would be logged on every read cycle
-                LOGGER.debug(e)
+                LOGGER.debug(err)
         LOGGER.info("Read %d parameters", length)
         self.parameters.parse(data)
 
@@ -90,9 +90,9 @@ class Luxtronik:
         for _ in range(0, length):
             try:
                 data.append(struct.unpack(">i", self._socket.recv(4))[0])
-            except struct.error as e:
+            except struct.error as err:
                 # not logging this as error as it would be logged on every read cycle
-                LOGGER.debug(e)
+                LOGGER.debug(err)
         LOGGER.info("Read %d calculations", length)
         self.calculations.parse(data)
 
@@ -106,8 +106,8 @@ class Luxtronik:
         for _ in range(0, length):
             try:
                 data.append(struct.unpack(">b", self._socket.recv(1))[0])
-            except struct.error as e:
+            except struct.error as err:
                 # not logging this as error as it would be logged on every read cycle
-                LOGGER.debug(e)
+                LOGGER.debug(err)
         LOGGER.info("Read %d visibilities", length)
         self.visibilities.parse(data)

--- a/luxtronik/parameters.py
+++ b/luxtronik/parameters.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 """Parse luxtonik parameters."""
 import logging
 
@@ -1168,6 +1170,9 @@ class Parameters:
                 self.parameters[index] = parameter
 
     def _lookup(self, target, with_index=False):
+        # pylint: disable=too-many-return-statements,fixme
+        # TODO Evaluate whether logic can be re-arranged to get rid of the
+        # pylint error regarding too many return statements.
         """Lookup parameter by either id or name."""
         if isinstance(target, int):
             if with_index:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-module-docstring
 import setuptools
 
 with open("README.md", "r", encoding="utf8") as fh:


### PR DESCRIPTION
This adds a GitHub action that will lint all Python files with pylint. This will ensure that the code will be more consistent when multiple persons are working on it. Also it will warn us about potential issues.

In case we don't like specific rules, the linter can be disabled for specific files and code sections and also re-configured. The output is verbose and solutions to reported issues can typically be easily found by searching the Internet (TM).
