### PR TITLE
Add support for access level parameter

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -530,6 +530,19 @@ class SecOperationMode(SelectionBase):
     }
 
 
+class AccessLevel(SelectionBase):
+    """AccessLevel datatype, converts from and to list of AccessLevel codes"""
+
+    measurement_type = "selection"
+
+    codes = {
+        0: "user",
+        1: "after sales service",
+        2: "manufacturer",
+        3: "installer",
+    }
+
+
 class Unknown(Base):
     """Unknown datatype, fallback for unknown data."""
 

--- a/luxtronik/parameters.py
+++ b/luxtronik/parameters.py
@@ -4,6 +4,7 @@
 import logging
 
 from luxtronik.datatypes import (
+    AccessLevel,
     Kelvin,
     Celsius,
     CoolingMode,
@@ -131,7 +132,7 @@ class Parameters:
         104: Unknown("ID_Einst_AhpM_akt"),
         105: Celsius("ID_Soll_BWS_akt", True),
         106: Unknown("ID_Timer_Password"),
-        107: Unknown("ID_Einst_Zugangscode"),
+        107: AccessLevel("ID_Einst_Zugangscode", True),
         108: CoolingMode("ID_Einst_BA_Kuehl_akt", True),
         109: Unknown("ID_Sollwert_Kuehl1_akt"),
         110: Celsius("ID_Einst_KuehlFreig_akt", True),


### PR DESCRIPTION
This adds full support for parameter `107`. This parameter is used internally
to define the access level to all kind of additional data that is not available
for typical users.

The access level can be changed locally by entering special codes, which are
well known among most advanced users:

- `9445` -> `installer`
- `7113` -> `after sales service`

There is an additional mode that can be enabled by inserting a specially
crafted USB stick into the USB interface of the controller. This will
grant the user `manufacturer` access level.

In the end, though, these hurdles are all falling back to using parameter `107`
to define the access value.

Therefore the current access level can be read from this parameter and be
translated into a string via the `AccessLevel` datatype.

Additionally the current access level can be set by writing the correct value
to this specific parameter, essentially overcoming the access hurdles.

This has been tested locally by me and it works fine here. The strings are
those that are being used by the firmware when using `English` as language.

In German the values are: `Benutzer`, `Installateur`, `Kundendienst`, `Werk`.