### PR TITLE
Add source file linting for Markdown and YAML files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint source files
+on: [push]
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+      - name: Run markdownlint
+        run: markdownlint "**/*.md"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,6 @@
+---
 name: Lint source files
-on: [push]
+on: [push] # yamllint disable-line rule:truthy
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,16 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Run markdownlint
         run: markdownlint "**/*.md"
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install yamllint
+        run: pip install --user yamllint
+      - name: Run yamllint
+        run: yamllint .

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,44 +1,44 @@
-name: Publish Python 🐍 distributions 📦 to PyPI 
+---
+name: Publish Python 🐍 distributions 📦 to PyPI
 
-on: 
+on: # yamllint disable-line rule:truthy
   release:
     types: [published]
 
 jobs:
   build-n-publish:
-  
+
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-18.04
     steps:
-    
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-        
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,7 +1,6 @@
+---
 name: Pylint
-
-on: [push]
-
+on: [push] # yamllint disable-line rule:truthy
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,15 +8,15 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-    - name: Analysing the code with pylint
-      run: |
-        pylint $(git ls-files '*.py')
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+      - name: Analysing the code with pylint
+        run: |
+          pylint $(git ls-files '*.py')

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,4 @@
+---
 default: true
 MD013:
     code_blocks: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,3 @@
+default: true
+MD013:
+    code_blocks: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,1 @@
+extends: default

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,1 +1,2 @@
+---
 extends: default

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,2 +1,5 @@
 ---
 extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2018 Bouni
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ engineering**.
 
 This library can be installed via pip by issuing the following command:
 
-```
+```shell
 pip install luxtronik
 ```
 
@@ -49,7 +49,7 @@ can be found in the [luxtronik](luxtronik/) directory.
 
 The following example reads in data from the heat pump:
 
-```
+```python
 from luxtronik import Luxtronik
 
 l = Luxtronik('192.168.1.23', 8889)
@@ -77,7 +77,7 @@ print(t_forerun.unit) # gives you the unit of the value if known, °C for exampl
 
 The following example writes data to the heat pump:
 
-```
+```python
 from luxtronik import Luxtronik
 
 l = Luxtronik('192.168.1.23', 8889)
@@ -97,7 +97,7 @@ writing parameters that are not (yet) understood.
 You can disable that safeguard by passing `safe=False` to the Luxtronik class
 during initialization:
 
-```
+```python
 from luxtronik import Luxtronik
 
 l = Luxtronik('192.168.1.23', 8889, safe=False)
@@ -120,25 +120,23 @@ The fastest way to provide improvements to the code is is to use
 
 ## LICENSE
 
-```
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the “Software”),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-```
+> Permission is hereby granted, free of charge, to any person obtaining a
+> copy of this software and associated documentation files (the “Software”),
+> to deal in the Software without restriction, including without limitation
+> the rights to use, copy, modify, merge, publish, distribute, sublicense,
+> and/or sell copies of the Software, and to permit persons to whom the
+> Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+> THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+> FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+> DEALINGS IN THE SOFTWARE.
 
 [github-repo]: https://github.com/Bouni/python-luxtronik
 [issue-tracker]: https://github.com/Bouni/python-luxtronik/issues


### PR DESCRIPTION
This implements linting for Markdown and YAML files within the repository as GitHub actions. Upon pushing the linters will be triggered, checking if there are any issues with the file formats.

This ensures more consistency and quality throughout the project.

The linters that are being used are:

- yamllint: https://github.com/adrienverge/yamllint
- markdownlint: https://github.com/DavidAnson/markdownlint

Some minor issues have already been identified with the existing files. Those are also being addressed with this pull request in order to make (and hopefully keep) the linters happy.

In addition to that there are configuration files (`.yamllint.yml` and `.markdownlint.yml`) that can be used to fine-tune the linters.