### PR TITLE
Fix deprecation warning in workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pylint


### PR DESCRIPTION
This fixes a deprecation warning in the output of the `pylint` job:

```
Warning: The `set-output` command is deprecated and will be disabled
soon. Please upgrade to using Environment Files. For more information
see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

See [1] for more details.

Since this will become a more serious issue later this year, it needs to be addressed. It can be easily fixed by using `v4` of the `setup-python` GitHub action.

This fixes issue #51.

[1]: https://github.com/Bouni/python-luxtronik/actions/runs/3929482958/jobs/6718345175