### PR TITLE
Update code 3 of BivalenceLevel datatype

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -425,7 +425,7 @@ class BivalenceLevel(SelectionBase):
     codes = {
         1: "one compressor allowed to run",
         2: "two compressors allowed to run",
-        3: "additional compressor allowed to run",
+        3: "additional heat generator allowed to run",
     }
 
 


### PR DESCRIPTION
This updates code 3 of the `BivalenceLevel` datatype. This value indicates that additional heat sources may be used. It is NOT about the compressor.

Refer to the operating manual for details. It can be found in English [here](https://s3p.manualzz.com/store/data/054697098.pdf?key=d3cc293e6bcdaee2d95d71716f830bfb&r=1&fn=54697098.pdf&t=1673905309047&p=86400).

The relevant aspect of the manual describes it like this:

![grafik](https://user-images.githubusercontent.com/1918279/212770359-03094394-6d9c-44e1-8fc1-7acf771e13f2.png)