### PR TITLE
Add script to dump all values from Luxtronik controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ print(t_forerun.unit) # gives you the unit of the value if known, °C for exampl
 # check https://github.com/Bouni/luxtronik/blob/master/luxtronik/visibilities.py for values you might need
 ```
 
+In order to dump all known values from the Luxtronik controller, you can use
+the `dump-luxtronik.py` script in the following way:
+
+```python
+PYTHONPATH=. ./scripts/dump-luxtronik.py 192.168.1.5
+```
+
+The output of this script can be used to backup all values (e.g. before
+modifying them) and to get a better understanding about parameters (e.g. by
+looking for differences when comparing the output after doing some changes
+locally, etc.).
+
 ### WRITING VALUES TO HEAT PUMP
 
 The following example writes data to the heat pump:

--- a/scripts/dump-luxtronik.py
+++ b/scripts/dump-luxtronik.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python3
+
+from luxtronik import Luxtronik
+
+l = Luxtronik('192.168.88.11', 8889)
+
+print("="*80)
+print ('{:^80}'.format(' Parameters '))
+print("="*80)
+
+for n, p in l.parameters.parameters.items():
+    print(f"Number: {n:<5} Name: {p.name:<60} Type: {p.__class__.__name__:<20} Value: {p.value}")
+
+print("="*80)
+print ('{:^80}'.format(' Calculations '))
+print("="*80)
+
+for n, c in l.calculations.calculations.items():
+    print(f"Number: {n:<5} Name: {c.name:<60} Type: {c.__class__.__name__:<20} Value: {c.value}")
+
+print("="*80)
+print ('{:^80}'.format(' Visibilities '))
+print("="*80)
+
+for n, v in l.visibilities.visibilities.items():
+    print(f"Number: {n:<5} Name: {v.name:<60} Type: {v.__class__.__name__:<20} Value: {v.value}")

--- a/scripts/dump-luxtronik.py
+++ b/scripts/dump-luxtronik.py
@@ -4,9 +4,27 @@
 
 """Script to dump all values from Luxtronik controller"""
 
+import argparse
+
 from luxtronik import Luxtronik
 
-l = Luxtronik('192.168.88.11', 8889)
+parser = argparse.ArgumentParser(
+        description="Dumps all values from Luxtronik controller"
+    )
+parser.add_argument(
+        "ip",
+        help="IP address of Luxtronik controller to connect to"
+    )
+parser.add_argument(
+        "port",
+        nargs="?",
+        type=int,
+        default=8889,
+        help="Port to use to connect to Luxtronik controller"
+    )
+args = parser.parse_args()
+
+l = Luxtronik(args.ip, args.port)
 
 print("="*80)
 print(f"{' Parameter ': ^80}")

--- a/scripts/dump-luxtronik.py
+++ b/scripts/dump-luxtronik.py
@@ -1,25 +1,29 @@
 #! /usr/bin/env python3
 
+# pylint: disable=invalid-name
+
+"""Script to dump all values from Luxtronik controller"""
+
 from luxtronik import Luxtronik
 
 l = Luxtronik('192.168.88.11', 8889)
 
 print("="*80)
-print ('{:^80}'.format(' Parameters '))
+print(f"{' Parameter ': ^80}")
 print("="*80)
 
 for n, p in l.parameters.parameters.items():
     print(f"Number: {n:<5} Name: {p.name:<60} Type: {p.__class__.__name__:<20} Value: {p.value}")
 
 print("="*80)
-print ('{:^80}'.format(' Calculations '))
+print(f"{' Calculations ': ^80}")
 print("="*80)
 
 for n, c in l.calculations.calculations.items():
     print(f"Number: {n:<5} Name: {c.name:<60} Type: {c.__class__.__name__:<20} Value: {c.value}")
 
 print("="*80)
-print ('{:^80}'.format(' Visibilities '))
+print(f"{' Visibilities ': ^80}")
 print("="*80)
 
 for n, v in l.visibilities.visibilities.items():


### PR DESCRIPTION
This adds a script that will allow users to dump all known values from
the Luxtronik controller, including:

- parameters
- calculations
- visibilities

The script itself was taken from a [Gist][gist].

In addition to that a few changes have been made:

- Changes to code to stay compliant with `pylint`
- Implementation of argument parsing via `argparse`

This change closes https://github.com/Bouni/python-luxtronik/issues/59.

[gist]: https://gist.github.com/Bouni/cf0dc2c7c53c32deeb264803ec350e5c