### PR TITLE
Make Kelvin datatype consistent to Celsius

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -140,7 +140,7 @@ class Kelvin(Base):
         return value / 10
 
     def to_heatpump(self, value):
-        return int(value * 10)
+        return int(float(value) * 10)
 
 
 class Pressure(Base):


### PR DESCRIPTION
This is a small change to the Kelvin datatype to make it consistent with the Celsius datatype, since they were inconsistent previously.

This will allow us to refactor the code later on more easily (e.g. have some kind of temperature super class, etc.).

This addresses and closes #58.