### PR TITLE
Replace pylint with ruff in GH Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,22 @@ jobs:
         run: pip install --user yamllint
       - name: Run yamllint
         run: yamllint .
+  pylint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pylint
+        run: pip install pylint
+      - name: Run pylint
+        run: pylint $(git ls-files '*.py')
   ruff:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install yamllint
         run: pip install --user yamllint
       - name: Run yamllint
         run: yamllint .
-  pylint:
+  ruff:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pylint
-        run: pip install pylint
-      - name: Run pylint
-        run: pylint $(git ls-files '*.py')
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff $(git ls-files '*.py')

--- a/luxtronik/__init__.py
+++ b/luxtronik/__init__.py
@@ -12,7 +12,7 @@ import time
 from luxtronik.calculations import Calculations
 from luxtronik.parameters import Parameters
 from luxtronik.visibilities import Visibilities
-from luxtronik.discover import discover
+from luxtronik.discover import discover # noqa: F401
 
 # endregion Imports
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ["luxtronik*"]
+
+[tool.ruff]
+line-length = 120


### PR DESCRIPTION
This morning I heared the Epsiode 400 of the [Talk Python Podcast](https://talkpython.fm/episodes/show/400/ruff-the-fast-rust-based-python-linter) in which they spoke about `ruff` a new linter written in Rust that  10-110 times faster than other liters.
So I thought wh not use it instead of pylint which is the slowest in their comparison:

![](https://user-images.githubusercontent.com/1309177/212613422-7faaf278-706b-4294-ad92-236ffcab3430.svg)

