### PR TITLE
Add black in RO mode to lint GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,32 +30,26 @@ jobs:
         run: yamllint .
   black:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install black
         run: pip install black
       - name: Run black
         run: black --check --verbose $(git ls-files '*.py')
   pylint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install pytest
         run: pip install pytest
       - name: Install pylint
@@ -64,16 +58,13 @@ jobs:
         run: pylint $(git ls-files '*.py')
   ruff:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install ruff
         run: pip install ruff
       - name: Run ruff

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,22 @@ jobs:
         run: pip install --user yamllint
       - name: Run yamllint
         run: yamllint .
+  vlack:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install black
+        run: pip install black
+      - name: Run black
+        run: black --check --verbose $(git ls-files '*.py')
   pylint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         run: pip install --user yamllint
       - name: Run yamllint
         run: yamllint .
-  vlack:
+  black:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,16 +6,13 @@ on: # yamllint disable-line rule:truthy
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install pytest
         run: pip install pytest pytest-cov
       - name: Run pytest


### PR DESCRIPTION
As discussed in #77 I've added `black` to the lint CI job.

Info: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#writeback-and-reporting