### PR TITLE
Add mapping for PV max to SwitchoffFile datatype

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -456,6 +456,7 @@ class SwitchoffFile(SelectionBase):
         8: "lower usage limit",
         9: "no request",
         11: "flow rate",
+        19: "PV max",
     }
 
 


### PR DESCRIPTION
As demonstrated in #89 the value 19 for the SwitchoffFile datatype represents `PV max`.

This change adds the entry accordingly to make the mapping available for consumers of the datatype module.

Fixes #89.