### PR TITLE
issue-91: Return the raw value instead of "None" in the __str__ method of the data fields

### DIFF
--- a/luxtronik/calculations.py
+++ b/luxtronik/calculations.py
@@ -303,19 +303,17 @@ class Calculations:
             calculation = self._calculations.get(index, False)
             # index is not version info (index 81 up to 91), proceed normally
             if calculation is not False and index not in range(81, 91):
-                calculation.value = calculation.from_heatpump(data)
+                calculation.raw = data
                 continue
             # index is version info, parse entire range from 81 up to 91 as version string
             if calculation is not False and index in range(81, 91):
-                calculation.value = calculation.from_heatpump(
-                    raw_data[index : index + 9]
-                )
+                calculation.raw = raw_data[index : index + 9]
                 continue
             # index is outside the known range, create it as unknown
             if calculation is False and index not in range(81, 91):
                 # LOGGER.warning("Calculation '%d' not in list of calculations", index)
                 calculation = Unknown(f"Unknown_Calculation_{index}")
-                calculation.value = calculation.from_heatpump(data)
+                calculation.raw = data
                 self._calculations[index] = calculation
 
     def _lookup(self, target):

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -10,7 +10,10 @@ class Base:
     measurement_type = None
 
     def __init__(self, name, writeable=False):
-        self.value = None
+        """Initialize the base data field class. Set the initial raw value to None"""
+        # save the raw value only since the user value
+        # could be build at any time
+        self._raw = None
         self.name = name
         self.writeable = writeable
 
@@ -22,11 +25,34 @@ class Base:
         """Converts value from heatpump units."""
         return value
 
+    @property
+    def value(self):
+        """Return the stored value converted from heatpump units."""
+        return self.from_heatpump(self._raw)
+
+    @value.setter
+    def value(self, value):
+        """Converts the value into heatpump units and store it."""
+        self._raw = self.to_heatpump(value)
+
+    @property
+    def raw(self):
+        """Return the stored raw data."""
+        return self._raw
+
+    @raw.setter
+    def raw(self, raw):
+        """Store the raw data."""
+        self._raw = raw
+
     def __repr__(self):
         return str(self.value)
 
     def __str__(self):
-        return str(self.value)
+        value = self.value
+        if value is not None:
+            return str(value)
+        return str(self.raw)
 
 
 class SelectionBase(Base):

--- a/luxtronik/parameters.py
+++ b/luxtronik/parameters.py
@@ -1167,11 +1167,11 @@ class Parameters:
         for index, data in enumerate(raw_data):
             parameter = self._parameters.get(index, False)
             if parameter is not False:
-                parameter.value = parameter.from_heatpump(data)
+                parameter.raw = data
             else:
                 # LOGGER.warning("Parameter '%d' not in list of parameters", index)
                 parameter = Unknown(f"Unknown_Parameter_{index}")
-                parameter.value = parameter.from_heatpump(data)
+                parameter.raw = data
                 self._parameters[index] = parameter
 
     def _lookup(self, target, with_index=False):

--- a/luxtronik/visibilities.py
+++ b/luxtronik/visibilities.py
@@ -376,11 +376,11 @@ class Visibilities:
         for index, data in enumerate(raw_data):
             visibility = self._visibilities.get(index, False)
             if visibility is not False:
-                visibility.value = visibility.from_heatpump(data)
+                visibility.raw = data
             else:
                 # LOGGER.warning("Visibility '%d' not in list of visibilities", index)
                 visibility = Unknown(f"Unknown_Parameter_{index}")
-                visibility.value = visibility.from_heatpump(data)
+                visibility.raw = data
                 self._visibilities[index] = visibility
 
     def _lookup(self, target):

--- a/scripts/dump-changes.py
+++ b/scripts/dump-changes.py
@@ -37,43 +37,43 @@ while True:
     for number, param in this_params:
         key = f"para_{number}"
         prev_param = prev_params.get(number)
-        if param.value != prev_param.value:
+        if param.raw != prev_param.raw:
             changes[key] = (
                 f"para: Number: {number:<5} Name: {prev_param.name:<60} "
-                + f"Value: {prev_param.value} -> {param.value}"
+                + f"Value: {prev_param} -> {param}"
             )
         elif key in changes:
             changes[key] = (
                 f"para: Number: {number:<5} Name: {prev_param.name:<60} "
-                + f"Value: {prev_param.value} -> reverted"
+                + f"Value: {prev_param} -> reverted"
             )
 
     for number, calc in this_calcs:
         key = f"calc_{number}"
         prev_calc = prev_calcs.get(number)
-        if calc.value != prev_calc.value:
+        if calc.raw != prev_calc.raw:
             changes[key] = (
                 f"calc: Number: {number:<5} Name: {prev_calc.name:<60} "
-                + f"Value: {prev_calc.value} -> {calc.value}"
+                + f"Value: {prev_calc} -> {calc}"
             )
         elif key in changes:
             changes[key] = (
                 f"calc: Number: {number:<5} Name: {prev_calc.name:<60} "
-                + f"Value: {prev_calc.value} -> reverted"
+                + f"Value: {prev_calc} -> reverted"
             )
 
     for number, visi in this_visis:
         key = f"visi_{number}"
         prev_visi = prev_visis.get(number)
-        if visi.value != prev_visi.value:
+        if visi.raw != prev_visi.raw:
             changes[key] = (
                 f"visi: Number: {number:<5} Name: {prev_visi.name:<60} "
-                + f"Value: {prev_visi.value} -> {visi.value}"
+                + f"Value: {prev_visi} -> {visi}"
             )
         elif key in changes:
             changes[key] = (
                 f"visi: Number: {number:<5} Name: {prev_visi.name:<60} "
-                + f"Value: {prev_visi.value} -> reverted"
+                + f"Value: {prev_visi} -> reverted"
             )
 
     # Print changes

--- a/scripts/dump-luxtronik.py
+++ b/scripts/dump-luxtronik.py
@@ -33,7 +33,7 @@ print("=" * 80)
 for number, param in parameters:
     print(
         f"Number: {number:<5} Name: {param.name:<60} "
-        + f"Type: {param.__class__.__name__:<20} Value: {param.value}"
+        + f"Type: {param.__class__.__name__:<20} Value: {param}"
     )
 
 print("=" * 80)
@@ -43,7 +43,7 @@ print("=" * 80)
 for number, calc in calculations:
     print(
         f"Number: {number:<5} Name: {calc.name:<60} "
-        + f"Type: {calc.__class__.__name__:<20} Value: {calc.value}"
+        + f"Type: {calc.__class__.__name__:<20} Value: {calc}"
     )
 
 print("=" * 80)
@@ -53,5 +53,5 @@ print("=" * 80)
 for number, visi in visibilities:
     print(
         f"Number: {number:<5} Name: {visi.name:<60} "
-        + f"Type: {visi.__class__.__name__:<20} Value: {visi.value}"
+        + f"Type: {visi.__class__.__name__:<20} Value: {visi}"
     )


### PR DESCRIPTION
If the selection value is unknown, output the raw value instead of None to simplify the "reverse engineering".

fixes #91 

Update:
Summary of the changes:
- The data field class `Base` now stores the raw value instead of the already converted "user value"
- Added a property `Base.Raw` to set and get the stored raw value directly
- Added a property `Base.Value` to get the stored raw value converted tothe "user value"
- Added a property `Base.Value` to set the stored value by a "user value" which is converted to raw data
- The string representation `Base.__str__` now output the raw value if the "user value" is None
- The script `dump-luxtronik.py` now uses the string representation of the data field class