### PR TITLE
issue-93: Also output the suggested changes of the 'black' workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install black
         run: pip install black
       - name: Run black
-        run: black --check --verbose $(git ls-files '*.py')
+        run: black --diff --check --verbose $(git ls-files '*.py')
   pylint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The "black" workflow only states that some files should be changed, but does not report these changes.
Fixed this by adding a --diff option to the call.

Fixes #93