### PR TITLE
issue-49: Convert some datatype functions into class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ l.write(parameters)
 
 # If you're not sure what values to write, you can get all available options:
 
-print(parameters.get("ID_Ba_Hz_akt").options) # returns a list of possible values to write, ['Automatic', 'Second heatsource', 'Party', 'Holidays', 'Off'] for example
+print(parameters.get("ID_Ba_Hz_akt").options()) # returns a list of possible values to write, ['Automatic', 'Second heatsource', 'Party', 'Holidays', 'Off'] for example
 ```
 
 **NOTE:** Writing values to the heat pump is particulary dangerous as this is

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -17,11 +17,13 @@ class Base:
         self.name = name
         self.writeable = writeable
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         """Converts value into heatpump units."""
         return value
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         """Converts value from heatpump units."""
         return value
 
@@ -60,18 +62,20 @@ class SelectionBase(Base):
 
     codes = {}
 
-    @property
-    def options(self):
+    @classmethod
+    def options(cls):
         """Return list of all available options."""
-        return [value for _, value in self.codes.items()]
+        return [value for _, value in cls.codes.items()]
 
-    def from_heatpump(self, value):
-        if value in self.codes:
-            return self.codes.get(value)
+    @classmethod
+    def from_heatpump(cls, value):
+        if value in cls.codes:
+            return cls.codes.get(value)
         return None
 
-    def to_heatpump(self, value):
-        for index, code in self.codes.items():
+    @classmethod
+    def to_heatpump(cls, value):
+        for index, code in cls.codes.items():
             if code == value:
                 return index
         return None
@@ -82,10 +86,12 @@ class Celsius(Base):
 
     measurement_type = "celsius"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(float(value) * 10)
 
 
@@ -94,10 +100,12 @@ class Bool(Base):
 
     measurement_type = "boolean"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return bool(value)
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value)
 
 
@@ -124,10 +132,12 @@ class IPAddress(Base):
 
     measurement_type = "ipaddress"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return socket.inet_ntoa(struct.pack(">i", value))
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return struct.unpack(">i", socket.inet_aton(value))[0]
 
 
@@ -136,12 +146,14 @@ class Timestamp(Base):
 
     measurement_type = "timestamp"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         if value > 0:
             return datetime.datetime.fromtimestamp(value)
         return datetime.datetime.fromtimestamp(0)
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return datetime.datetime.timestamp(value)
 
 
@@ -156,10 +168,12 @@ class Kelvin(Base):
 
     measurement_type = "kelvin"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(float(value) * 10)
 
 
@@ -168,10 +182,12 @@ class Pressure(Base):
 
     measurement_type = "bar"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 100
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value * 100)
 
 
@@ -180,10 +196,12 @@ class Percent(Base):
 
     measurement_type = "percent"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value * 10)
 
 
@@ -192,10 +210,12 @@ class Percent2(Base):
 
     measurement_type = "percent"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value)
 
 
@@ -216,10 +236,12 @@ class Energy(Base):
 
     measurement_type = "energy"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value * 10)
 
 
@@ -228,10 +250,12 @@ class Voltage(Base):
 
     measurement_type = "voltage"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value * 10)
 
 
@@ -240,10 +264,12 @@ class Hours(Base):
 
     measurement_type = "hours"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return value / 10
 
-    def to_heatpump(self, value):
+    @classmethod
+    def to_heatpump(cls, value):
         return int(value * 10)
 
 
@@ -276,7 +302,8 @@ class Version(Base):
 
     measurement_type = "version"
 
-    def from_heatpump(self, value):
+    @classmethod
+    def from_heatpump(cls, value):
         return "".join([chr(c) for c in value]).strip("\x00")
 
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -107,8 +107,8 @@ class TestSelectionBase:
 
         a = SelectionBase("")
         a.codes = {0: "a", 1: "b", 2: "c"}
-        assert len(a.options) == 3
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 3
+        assert a.options() == list(a.codes.values())
 
     def test_from_heatpump(self):
         """Test cases for from_heatpump function"""
@@ -564,8 +564,8 @@ class TestHeatingMode:
         """Test cases for options property"""
 
         a = HeatingMode("")
-        assert len(a.options) == 5
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 5
+        assert a.options() == list(a.codes.values())
 
 
 class TestCoolingMode:
@@ -583,7 +583,7 @@ class TestCoolingMode:
         """Test cases for options property"""
 
         a = CoolingMode("")
-        assert len(a.options) == 2
+        assert len(a.options()) == 2
 
 
 class TestHotWaterMode:
@@ -601,8 +601,8 @@ class TestHotWaterMode:
         """Test cases for options property"""
 
         a = HotWaterMode("")
-        assert len(a.options) == 5
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 5
+        assert a.options() == list(a.codes.values())
 
 
 class TestPoolMode:
@@ -620,8 +620,8 @@ class TestPoolMode:
         """Test cases for options property"""
 
         a = PoolMode("")
-        assert len(a.options) == 4
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 4
+        assert a.options() == list(a.codes.values())
 
 
 class TestMixedCircuitMode:
@@ -639,8 +639,8 @@ class TestMixedCircuitMode:
         """Test cases for options property"""
 
         a = MixedCircuitMode("")
-        assert len(a.options) == 4
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 4
+        assert a.options() == list(a.codes.values())
 
 
 class TestSolarMode:
@@ -658,8 +658,8 @@ class TestSolarMode:
         """Test cases for options property"""
 
         a = SolarMode("")
-        assert len(a.options) == 5
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 5
+        assert a.options() == list(a.codes.values())
 
 
 class TestVentilationMode:
@@ -677,8 +677,8 @@ class TestVentilationMode:
         """Test cases for options property"""
 
         a = VentilationMode("")
-        assert len(a.options) == 4
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 4
+        assert a.options() == list(a.codes.values())
 
 
 class TestHeatpumpCode:
@@ -696,8 +696,8 @@ class TestHeatpumpCode:
         """Test cases for options property"""
 
         a = HeatpumpCode("")
-        assert len(a.options) == 68
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 68
+        assert a.options() == list(a.codes.values())
 
 
 class TestBivalenceLevel:
@@ -715,8 +715,8 @@ class TestBivalenceLevel:
         """Test cases for options property"""
 
         a = BivalenceLevel("")
-        assert len(a.options) == 3
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 3
+        assert a.options() == list(a.codes.values())
 
 
 class TestOperationMode:
@@ -734,8 +734,8 @@ class TestOperationMode:
         """Test cases for options property"""
 
         a = OperationMode("")
-        assert len(a.options) == 8
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 8
+        assert a.options() == list(a.codes.values())
 
 
 class TestSwitchoffFile:
@@ -753,8 +753,8 @@ class TestSwitchoffFile:
         """Test cases for options property"""
 
         a = SwitchoffFile("")
-        assert len(a.options) == 11
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 11
+        assert a.options() == list(a.codes.values())
 
 
 class TestMainMenuStatusLine1:
@@ -772,8 +772,8 @@ class TestMainMenuStatusLine1:
         """Test cases for options property"""
 
         a = MainMenuStatusLine1("")
-        assert len(a.options) == 8
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 8
+        assert a.options() == list(a.codes.values())
 
 
 class TestMainMenuStatusLine2:
@@ -791,8 +791,8 @@ class TestMainMenuStatusLine2:
         """Test cases for options property"""
 
         a = MainMenuStatusLine2("")
-        assert len(a.options) == 2
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 2
+        assert a.options() == list(a.codes.values())
 
 
 class TestSecOperationMode:
@@ -810,8 +810,8 @@ class TestSecOperationMode:
         """Test cases for options property"""
 
         a = SecOperationMode("")
-        assert len(a.options) == 13
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 13
+        assert a.options() == list(a.codes.values())
 
 
 class TestAccessLevel:
@@ -829,8 +829,8 @@ class TestAccessLevel:
         """Test cases for options property"""
 
         a = AccessLevel("")
-        assert len(a.options) == 4
-        assert a.options == list(a.codes.values())
+        assert len(a.options()) == 4
+        assert a.options() == list(a.codes.values())
 
 
 class TestUnknown:


### PR DESCRIPTION
As discussed in #49 the implementation of the functions `Base.to_heatpump`, `Base.from_heatpump` and `SelectionBase.options` are correspond to class methods. But are not yet offered as such.  This pull-request transform them into class-methods.