### PR TITLE
Introduce datatype MajorMinorVersion to handle calculation 258

### DIFF
--- a/luxtronik/calculations.py
+++ b/luxtronik/calculations.py
@@ -29,6 +29,7 @@ from luxtronik.datatypes import (
     Timestamp,
     Unknown,
     Version,
+    MajorMinorVersion,
     Voltage,
 )
 
@@ -289,7 +290,7 @@ class Calculations:
             255: Unknown("Unknown_Calculation_255"),
             256: Unknown("Unknown_Calculation_256"),
             257: Power("Heat_Output"),
-            258: Unknown("Unknown_Calculation_258"),
+            258: MajorMinorVersion("RBE_Version"),
             259: Unknown("Unknown_Calculation_259"),
         }
 

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -388,7 +388,7 @@ class MajorMinorVersion(Base):
         if value > 0:
             major = value // 100
             minor = value % 100
-            return ".".join(str(x) for x in [major, minor])
+            return f"{major}.{minor}"
         return "0"
 
 

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -378,6 +378,20 @@ class Version(Base):
         return "".join([chr(c) for c in value]).strip("\x00")
 
 
+class MajorMinorVersion(Base):
+    """MajorMinorVersion datatype, converts from and to a RBEVersion"""
+
+    datatype_class = "version"
+
+    @classmethod
+    def from_heatpump(cls, value):
+        if value > 0:
+            major = value // 100
+            minor = value % 100
+            return ".".join(str(x) for x in [major, minor])
+        return "0"
+
+
 class Icon(Base):
     """Icon datatype, converts from and to Icon."""
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -30,6 +30,7 @@ from luxtronik.datatypes import (
     Level,
     Count,
     Version,
+    MajorMinorVersion,
     Icon,
     HeatingMode,
     CoolingMode,
@@ -635,6 +636,31 @@ class TestVersion:
         assert Version.from_heatpump(bytes([51, 46, 56, 56, 00])) == "3.88"
         assert Version.from_heatpump(bytes([00, 51, 46, 56, 56, 00])) == "3.88"
         assert Version.from_heatpump(bytes([48])) == "0"
+
+
+class TestMajorMinorVersion:
+    """Test suite for MajorMinorVersion datatype"""
+
+    def test_init(self):
+        """Test cases for initialization"""
+
+        a = MajorMinorVersion("numeric_version")
+        assert a.name == "numeric_version"
+        assert a.datatype_class == "version"
+        assert a.datatype_unit is None
+
+    def test_from_heatpump(self):
+        """Test cases for from_heatpump function"""
+
+        # Reported value from https://github.com/Bouni/python-luxtronik/issues/99
+        assert MajorMinorVersion.from_heatpump(112) == "1.12"
+
+        # Reported value when RBE is not installed
+        assert MajorMinorVersion.from_heatpump(0) == "0"
+
+        # Other values (not seen in the wild yet)
+        assert MajorMinorVersion.from_heatpump(12) == "0.12"
+        assert MajorMinorVersion.from_heatpump(-1) == "0"
 
 
 class TestIcon:


### PR DESCRIPTION
This introduced a new datatype (`MajorMinorVersion`) that is used to interpret calculation 258. It has been reported (see #99) that this calculation is used to encode the version information from the "Raumbedieneinheit" (RBE).

For me this value is 0 (don't have this hardware), for the reporter of #99 it is `112`, which is being shown as `1.12` in the web interface.

The pull request also contains test cases that cover the currently known values.