### PR TITLE
Add yamllint and markdownlint to pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,18 @@ repos:
     hooks:
       - id: black
         files: ^((luxtronik|pylint|scripts|tests)/.+)?[^/]+\.py$
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.35.0
+    hooks:
+      - id: markdownlint
+        args:
+          - --fix
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
 # - repo: https://github.com/charliermarsh/ruff-pre-commit
 #   rev: v0.0.235
 #   hooks:


### PR DESCRIPTION
In order to get a consistent quality of our README.md (and probably other Markdown files to come) we should add markdownlint to our pre-commit-hooks.  
Yamllint was added to ensure the .pre-commit-hooks.yaml is formated correctly as well.