### PR TITLE
Create a VersionChild datatype

### DIFF
--- a/luxtronik/calculations.py
+++ b/luxtronik/calculations.py
@@ -5,6 +5,7 @@ from luxtronik.datatypes import (
     BivalenceLevel,
     Bool,
     Celsius,
+    Character,
     Count,
     Energy,
     Errorcode,
@@ -28,7 +29,6 @@ from luxtronik.datatypes import (
     SwitchoffFile,
     Timestamp,
     Unknown,
-    Version,
     MajorMinorVersion,
     Voltage,
 )
@@ -122,7 +122,16 @@ class Calculations:
             78: HeatpumpCode("ID_WEB_Code_WP_akt"),
             79: BivalenceLevel("ID_WEB_BIV_Stufe_akt"),
             80: OperationMode("ID_WEB_WP_BZ_akt"),
-            81: Version("ID_WEB_SoftStand"),
+            81: Character("ID_WEB_SoftStand_0"),
+            82: Character("ID_WEB_SoftStand_1"),
+            83: Character("ID_WEB_SoftStand_2"),
+            84: Character("ID_WEB_SoftStand_3"),
+            85: Character("ID_WEB_SoftStand_4"),
+            86: Character("ID_WEB_SoftStand_5"),
+            87: Character("ID_WEB_SoftStand_6"),
+            88: Character("ID_WEB_SoftStand_7"),
+            89: Character("ID_WEB_SoftStand_8"),
+            90: Character("ID_WEB_SoftStand_9"),
             91: IPv4Address("ID_WEB_AdresseIP_akt"),
             92: IPv4Address("ID_WEB_SubNetMask_akt"),
             93: IPv4Address("ID_WEB_Add_Broadcast"),
@@ -301,16 +310,9 @@ class Calculations:
         """Parse raw calculations data."""
         for index, data in enumerate(raw_data):
             calculation = self._calculations.get(index, False)
-            # index is not version info (index 81 up to 91), proceed normally
-            if calculation is not False and index not in range(81, 91):
+            if calculation is not False:
                 calculation.raw = data
-                continue
-            # index is version info, parse entire range from 81 up to 91 as version string
-            if calculation is not False and index in range(81, 91):
-                calculation.raw = raw_data[index : index + 9]
-                continue
-            # index is outside the known range, create it as unknown
-            if calculation is False and index not in range(81, 91):
+            else:
                 # LOGGER.warning("Calculation '%d' not in list of calculations", index)
                 calculation = Unknown(f"Unknown_Calculation_{index}")
                 calculation.raw = data

--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -328,14 +328,16 @@ class Count(Base):
     datatype_class = "count"
 
 
-class Version(Base):
-    """Version datatype, converts from and to a Heatpump Version."""
+class Character(Base):
+    """Character datatype, converts from and to a Character."""
 
-    datatype_class = "version"
+    datatype_class = "character"
 
     @classmethod
     def from_heatpump(cls, value):
-        return "".join([chr(c) for c in value]).strip("\x00")
+        if value == 0:
+            return ""
+        return chr(value)
 
 
 class MajorMinorVersion(Base):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -30,7 +30,7 @@ from luxtronik.datatypes import (
     Flow,
     Level,
     Count,
-    Version,
+    Character,
     MajorMinorVersion,
     Icon,
     HeatingMode,
@@ -680,24 +680,25 @@ class TestCount:
         assert a.datatype_unit is None
 
 
-class TestVersion:
-    """Test suite for Version datatype"""
+class TestCharacter:
+    """Test suite for Character datatype"""
 
     def test_init(self):
         """Test cases for initialization"""
 
-        a = Version("version")
-        assert a.name == "version"
-        assert a.datatype_class == "version"
+        a = Character("my_name")
+        assert a.name == "my_name"
+        assert a.datatype_class == "character"
         assert a.datatype_unit is None
 
     def test_from_heatpump(self):
         """Test cases for from_heatpump function"""
 
-        assert Version.from_heatpump(bytes([51, 46, 56, 56])) == "3.88"
-        assert Version.from_heatpump(bytes([51, 46, 56, 56, 00])) == "3.88"
-        assert Version.from_heatpump(bytes([00, 51, 46, 56, 56, 00])) == "3.88"
-        assert Version.from_heatpump(bytes([48])) == "0"
+        assert Character.from_heatpump(0) == ""
+        assert Character.from_heatpump(51) == "3"
+        assert Character.from_heatpump(46) == "."
+        assert Character.from_heatpump(56) == "8"
+        assert Character.from_heatpump(48) == "0"
 
 
 class TestMajorMinorVersion:


### PR DESCRIPTION
This works towards #122.

In `calculations.py` we have an exceptional handling for the fields 81-90, since these ten fields contain the version information. Positions 82-90 were uninhabited; with this patch, a new `VersionChild` sits there and gobbles the value for its parent.

A new flag `datatype_internal` indicates, that this datatype is only internal and the iterator of `Calculations` will skip this entry.