### PR TITLE
Attempt to run CI only once

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@
 name: Lint source files
 on: # yamllint disable-line rule:truthy
   push:
+    branches:
+      - main
   pull_request:
 jobs:
   markdownlint:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,8 @@
 name: Run unit tests
 on: # yamllint disable-line rule:truthy
   push:
+    branches:
+      - main
   pull_request:
 jobs:
   pytest:


### PR DESCRIPTION
This is an attempt to prevent our CI pipeline from running twice for every PR.
There is no need to run it `on: push` for a PR and `on: pull-request` as well. 
