### PR TITLE
Use round instead of int in `datatypes.py`

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -138,7 +138,7 @@ class ScalingBase(Base):
 
     @classmethod
     def to_heatpump(cls, value):
-        raw = int(float(value) / cls.scaling_factor)
+        raw = round(float(value) / cls.scaling_factor)
         return raw
 
 
@@ -299,7 +299,7 @@ class Hours2(Base):
 
     @classmethod
     def to_heatpump(cls, value):
-        return int((value - 1) * 2)
+        return round((value - 1) * 2)
 
 
 class Minutes(Base):


### PR DESCRIPTION
`int(some_float)` always rounds towards zero and this is (maybe) not what is expected.

This PR suggests to replace `int()` by `round()`.