### PR TITLE
Two staged coverage comment attempt

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+---
+name: Comment coverage report on the pull request
+on: # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows: ["pytest"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        # yamllint disable rule:line-length
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+        # yamllint enable rule:line-length
+      - name: Unzip artifact
+        run: unzip pr.zip
+      - name: Read the PR number from file
+        id: pr_number
+        uses: juliangruber/read-file-action@v1.1.7
+        with:
+          path: ./PR-number.txt
+      - name: Publish pytest coverage as comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          issue-number: ${{ steps.pr_number.outputs.content }}
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,18 +5,12 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
   pull_request:
-    branches:
-      - main
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    # permissions:
-    #   pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Print branch name
-        run: echo The current branch is ${GITHUB_REF##*/}
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -29,9 +23,13 @@ jobs:
           set -o pipefail
           PYTHONPATH=. pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=luxtronik tests/ | tee pytest-coverage.txt
         # yamllint enable rule:line-length
-      - name: Publish pytest coverage as comment
-        uses: MishaKav/pytest-coverage-comment@main
+      - name: Save PR number and coverage results
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/PR-number.txt
+          cp ./pytest-coverage.txt ./pr/pytest-coverage.txt
+          cp ./pytest.xml ./pr/pytest.xml
+      - uses: actions/upload-artifact@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
+          name: pr
+          path: pr/


### PR DESCRIPTION
This is a two staged approach to fix the permission problme when posting the coverage report on a PR that fomes from a forked repo.

Found here:

- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://github.com/MishaKav/pytest-coverage-comment/issues/68#issuecomment-1836219787 