### PR TITLE
Fix workflow_run name

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@
 name: Comment coverage report on the pull request
 on: # yamllint disable-line rule:truthy
   workflow_run:
-    workflows: ["pytest"]
+    workflows: ["Run unit tests"]
     types:
       - completed
 


### PR DESCRIPTION
`workflows:`must contain the `name` of the other workflow, not the filename