### PR TITLE
Fix coverage comment

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 ---
-name: Comment coverage report on the pull request
+name: PR coverage comment
 on: # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["Run unit tests"]
@@ -14,11 +14,11 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         # yamllint disable rule:line-length
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -26,7 +26,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -39,11 +39,13 @@ jobs:
         run: unzip pr.zip
       - name: Read the PR number from file
         id: pr_number
-        uses: juliangruber/read-file-action@v1.1.7
+        uses: juliangruber/read-file-action@v1
         with:
           path: ./PR-number.txt
       - name: Publish pytest coverage as comment
-        uses: MishaKav/pytest-coverage-comment@main
+        # uses: MishaKav/pytest-coverage-comment@main
+        # Temporarily until PR#153 in MishaKav/pytest-coverage-comment is merged
+        uses: bouni/pytest-coverage-comment@workflow_run
         with:
           issue-number: ${{ steps.pr_number.outputs.content }}
           pytest-coverage-path: ./pytest-coverage.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install pytest
@@ -29,7 +29,7 @@ jobs:
           echo ${{ github.event.number }} > ./pr/PR-number.txt
           cp ./pytest-coverage.txt ./pr/pytest-coverage.txt
           cp ./pytest.xml ./pr/pytest.xml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
I finally fixed the coverage comment issue 🥳 

1. It is necessary to have a two staged solution because of security reasons, details can be found in GitHubs blog post: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

2. MishaKav/pytest-coverage-comment did not allow the `workflow_run` trigger which prevented the coverage report to be posted. I forked the repo, fixed the issue and opend https://github.com/MishaKav/pytest-coverage-comment/pull/153 . Until that PR is merged we can use my fork `bouni/pytest-coverage-comment@workflow_run`