### PR TITLE
Revert action to MishaKav/pytest-coverage-comment@main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,9 +43,7 @@ jobs:
         with:
           path: ./PR-number.txt
       - name: Publish pytest coverage as comment
-        # uses: MishaKav/pytest-coverage-comment@main
-        # Temporarily until PR#153 in MishaKav/pytest-coverage-comment is merged
-        uses: bouni/pytest-coverage-comment@workflow_run
+        uses: MishaKav/pytest-coverage-comment@main
         with:
           issue-number: ${{ steps.pr_number.outputs.content }}
           pytest-coverage-path: ./pytest-coverage.txt


### PR DESCRIPTION
My PR to [MishaKav/pytest-coverage-comment](https://github.com/MishaKav/pytest-coverage-comment/) has been merged and therefore we can revert back to the original action

Details see here: https://github.com/MishaKav/pytest-coverage-comment/pull/153#issuecomment-1940509467