### PR TITLE
Fix reading from socket

### DIFF
--- a/luxtronik/__init__.py
+++ b/luxtronik/__init__.py
@@ -252,6 +252,11 @@ class LuxtronikSocketInterface:
             missing = count - len(total_reading)
 
             reading = self._socket.recv( missing )
+
+            if len(reading) == 0:
+                LOGGER.error("%s: Connection died.", self._host)
+                raise ConnectionError("Connection to %s died." % self._host)
+
             total_reading += reading
 
             if len(reading) is not missing:


### PR DESCRIPTION
Sometimes `self._socket.recv` returns fewer bytes than requested (for me, this happens sometimes over VPN). The current `try-check` in `read_*` is not helpful, since it just skews up the readings, e.g., if we only get 2 bytes for parameter 1, the remaining 2 bytes are then feed into parameter 2 and so on...

The current fix assures that the correct amount of bytes is read by introducing a new function `_read_bytes()`.