### PR TITLE
Refactor discover function

### DIFF
--- a/luxtronik/discover.py
+++ b/luxtronik/discover.py
@@ -6,64 +6,92 @@ import logging
 import socket
 
 from luxtronik.constants import (
-    LUXTRONIK_DISCOVERY_PORTS,
-    LUXTRONIK_DISCOVERY_TIMEOUT,
     LUXTRONIK_DISCOVERY_MAGIC_PACKET,
+    LUXTRONIK_DISCOVERY_PORTS,
     LUXTRONIK_DISCOVERY_RESPONSE_PREFIX,
+    LUXTRONIK_DISCOVERY_TIMEOUT,
 )
 
 LOGGER = logging.getLogger("Luxtronik.Discover")
 
+"""Discovery function for Luxtronik heat pump controllers."""
+
 
 def discover() -> list[tuple[str, int | None]]:
     """Broadcast discovery for Luxtronik heat pumps."""
-
     results: list[tuple[str, int | None]] = []
 
-    # pylint: disable=too-many-nested-blocks
     for port in LUXTRONIK_DISCOVERY_PORTS:
-        LOGGER.debug("Send discovery packets to port %s", port)
-        server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-        server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        server.bind(("", port))
-        server.settimeout(LUXTRONIK_DISCOVERY_TIMEOUT)
-
-        # send AIT magic broadcast packet
-        server.sendto(LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode(), ("<broadcast>", port))
-        LOGGER.debug("Sending broadcast request %s", LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode())
-
-        while True:
-            try:
-                recv_bytes, con = server.recvfrom(1024)
-                res = recv_bytes.decode("ascii", errors="ignore")
-                # if we receive what we just sent, continue
-                if res == LUXTRONIK_DISCOVERY_MAGIC_PACKET:
-                    continue
-                ip_address = con[0]
-                # if the response starts with the magic nonsense
-                if res.startswith(LUXTRONIK_DISCOVERY_RESPONSE_PREFIX):
-                    res_list = res.split(";")
-                    LOGGER.debug("Received response from %s %s", ip_address, str(res_list))
-                    try:
-                        res_port: int | None = int(res_list[2])
-                        if res_port is None or res_port < 1 or res_port > 65535:
-                            LOGGER.debug("Response contained an invalid port, ignoring")
-                            res_port = None
-                    except ValueError:
-                        res_port = None
-                    if res_port is None:
-                        LOGGER.debug(
-                            "Response did not contain a valid port number,"
-                            "an old Luxtronic software version might be the reason"
-                        )
-                    results.append((ip_address, res_port))
-                LOGGER.debug(
-                    "Received response from %s, but with wrong content, skipping",
-                    ip_address,
-                )
-                continue
-            # if the timeout triggers, go on an use the other broadcast port
-            except socket.timeout:
-                break
+        server = setup_broadcast_socket(port)
+        send_discovery_packet(server, port)
+        results.extend(collect_responses(server))
 
     return results
+
+
+def setup_broadcast_socket(port: int) -> socket.socket:
+    """Set up a broadcast socket for the given port."""
+    LOGGER.debug("Setting up broadcast socket on port %s", port)
+    server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    server.bind(("", port))
+    server.settimeout(LUXTRONIK_DISCOVERY_TIMEOUT)
+    return server
+
+
+def send_discovery_packet(server: socket.socket, port: int) -> None:
+    """Send discovery broadcast packet to the specified port."""
+    LOGGER.debug("Send discovery packets to port %s", port)
+    server.sendto(LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode(), ("<broadcast>", port))
+    LOGGER.debug("Sending broadcast request %s", LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode())
+
+
+def collect_responses(server: socket.socket) -> list[tuple[str, int | None]]:
+    """Collect responses from the server socket and return valid results."""
+    results = []
+
+    while True:
+        try:
+            recv_bytes, con = server.recvfrom(1024)
+            ip_address, res = handle_response(recv_bytes, con)
+            if res and res.startswith(LUXTRONIK_DISCOVERY_RESPONSE_PREFIX):
+                parsed_response = parse_response(res, ip_address)
+                if parsed_response:
+                    results.append(parsed_response)
+                else:
+                    LOGGER.debug("Received response from %s, but with wrong content, skipping", ip_address)
+        except socket.timeout:
+            break
+
+    return results
+
+
+def handle_response(recv_bytes: bytes, con: tuple[str, int]) -> tuple[str, str]:
+    """Handle received bytes and return the IP address and decoded response."""
+    ip_address = con[0]
+    res = recv_bytes.decode("ascii", errors="ignore")
+    if res == LUXTRONIK_DISCOVERY_MAGIC_PACKET:
+        LOGGER.debug("Received self-sent magic packet, ignoring")
+        return ip_address, ""
+    return ip_address, res
+
+
+def parse_response(res: str, ip_address: str) -> tuple[str, int | None]:
+    """Parse the discovery response and return the IP address and port, if valid."""
+    res_list = res.split(";")
+    LOGGER.debug("Received response from %s %s", ip_address, str(res_list))
+
+    try:
+        res_port: int | None = int(res_list[2])
+        if res_port < 1 or res_port > 65535:
+            LOGGER.debug("Response contained an invalid port, ignoring")
+            res_port = None
+    except (ValueError, IndexError):
+        res_port = None
+
+    if res_port is None:
+        LOGGER.debug(
+            "Response did not contain a valid port number, an old Luxtronic software version might be the reason"
+        )
+
+    return ip_address, res_port

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,153 @@
+"""Test suite for Luxtronik Discover"""
+
+import pytest
+from unittest import mock
+import socket
+
+from luxtronik.discover import (
+    discover,
+    setup_broadcast_socket,
+    send_discovery_packet,
+    collect_responses,
+    handle_response,
+    parse_response,
+)
+
+from luxtronik.constants import (
+    LUXTRONIK_DISCOVERY_MAGIC_PACKET,
+    LUXTRONIK_DISCOVERY_RESPONSE_PREFIX,
+    LUXTRONIK_DISCOVERY_TIMEOUT,
+)
+
+# Mock constants
+LUXTRONIK_DISCOVERY_PORTS = [1234]
+
+
+@pytest.fixture
+def mock_socket():
+    """Fixture to mock socket behavior."""
+    with mock.patch("socket.socket") as mock_socket:
+        yield mock_socket
+
+
+def test_setup_broadcast_socket(mock_socket):
+    """Test the setup_broadcast_socket function."""
+    mock_server = mock.Mock()
+    mock_socket.return_value = mock_server
+
+    server = setup_broadcast_socket(1234)
+
+    # Check that socket is initialized correctly
+    mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    mock_server.setsockopt.assert_called_once_with(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    mock_server.bind.assert_called_once_with(("", 1234))
+    mock_server.settimeout.assert_called_once_with(LUXTRONIK_DISCOVERY_TIMEOUT)
+
+    assert server == mock_server
+
+
+def test_send_discovery_packet(mock_socket):
+    """Test the send_discovery_packet function."""
+    mock_server = mock_socket.return_value
+
+    send_discovery_packet(mock_server, 1234)
+    # Verify that sendto was called with the correct arguments
+    expected_packet = LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode()
+    expected_address = ("<broadcast>", 1234)
+
+    mock_server.sendto.assert_called_once_with(expected_packet, expected_address)
+
+
+def test_handle_response():
+    """Test the handle_response function."""
+    recv_bytes = b"RESPONSE_PREFIX;data;1234"
+    con = ("192.168.1.100", 5678)
+
+    ip_address, res = handle_response(recv_bytes, con)
+
+    assert ip_address == "192.168.1.100"
+    assert res == "RESPONSE_PREFIX;data;1234"
+
+
+def test_handle_response_ignore_magic_packet():
+    """Test that handle_response ignores the magic packet response."""
+    recv_bytes = LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode()
+    con = ("192.168.1.100", 5678)
+
+    ip_address, res = handle_response(recv_bytes, con)
+
+    assert ip_address == "192.168.1.100"
+    assert res == ""  # Magic packet should be ignored
+
+
+def test_parse_response():
+    """Test the parse_response function."""
+    res = "RESPONSE_PREFIX;data;1234"
+    ip_address = "192.168.1.100"
+
+    result = parse_response(res, ip_address)
+
+    assert result == ("192.168.1.100", 1234)
+
+
+def test_parse_response_invalid_port():
+    """Test parse_response when the port is invalid."""
+    res = "RESPONSE_PREFIX;data;99999"  # Invalid port > 65535
+    ip_address = "192.168.1.100"
+
+    result = parse_response(res, ip_address)
+
+    assert result == ("192.168.1.100", None)
+
+
+def test_parse_response_missing_port():
+    """Test parse_response when the response doesn't have a port."""
+    res = "RESPONSE_PREFIX;data"
+    ip_address = "192.168.1.100"
+
+    result = parse_response(res, ip_address)
+
+    assert result == ("192.168.1.100", None)
+
+
+def test_collect_responses_timeout(mock_socket):
+    """Test collect_responses handling a socket timeout."""
+    mock_server = mock_socket.return_value
+
+    mock_server.recvfrom.side_effect = socket.timeout
+
+    results = collect_responses(mock_server)
+
+    assert results == []  # Timeout should return an empty result
+
+
+def test_collect_responses_with_valid_data(mock_socket):
+    """Test collect_responses with valid data."""
+    mock_server = mock_socket.return_value
+    mock_server.recvfrom.side_effect = [
+        (f"{LUXTRONIK_DISCOVERY_RESPONSE_PREFIX}1234".encode(), ("192.168.1.100", 5678)),
+        socket.timeout,
+    ]
+
+    results = collect_responses(mock_server)
+
+    assert results == [("192.168.1.100", 1234)]
+
+
+def test_discover(mock_socket):
+    """Test the discover function."""
+    mock_server = mock_socket.return_value
+
+    # Mock sendto for sending the discovery packet
+    mock_server.sendto = mock.Mock()
+
+    # Mock recvfrom for receiving the response
+    mock_server.recvfrom.side_effect = [
+        (f"{LUXTRONIK_DISCOVERY_RESPONSE_PREFIX}1234".encode(), ("192.168.1.100", 5678)),
+        socket.timeout,
+        socket.timeout,  # dummy to prevent stopIteration error
+    ]
+
+    results = discover()
+
+    assert results == [("192.168.1.100", 1234)]


### PR DESCRIPTION
As brought up in #73 the discover function was to large and cased ruff warnings.

This PR splits the discover function into smaller logical functions and adds unit tests