### PR TITLE
FIX switchoff reasons

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -666,17 +666,31 @@ class SwitchoffFile(SelectionBase):
     datatype_class = "selection"
 
     codes = {
-        1: "heatpump error",
-        2: "system error",
+        0: "heatpump error",
+        1: "system error",
+        2: "operation mode second heat generator",
         3: "evu lock",
-        4: "operation mode second heat generator",
         5: "air defrost",
         6: "maximal usage temperature",
         7: "minimal usage temperature",
         8: "lower usage limit",
         9: "no request",
+        10 : "external energy source",
         11: "flow rate",
+        12 : "low pressure pause",
+        13 : "superheating pause",
+        14 : "inverter pause",
+        15 : "desuperheater pause",
+        16 : "operation mode for switching over",
+        17 : "other shutdown",
+        18 : "min.flow cooling",
         19: "PV max",
+        20 : "hot gas pause",
+        21 : "overheating hot gas pause",
+        22 : "no request",
+        23 : "min. heat source out cooling",
+        24 : "LPC",
+        25 : "restart",
     }
 
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1009,13 +1009,13 @@ class TestSwitchoffFile:
         assert a.name == "switchoff_file"
         assert a.datatype_class == "selection"
         assert a.datatype_unit is None
-        assert len(a.codes) == 11
+        assert len(a.codes) == 25
 
     def test_options(self):
         """Test cases for options property"""
 
         a = SwitchoffFile("")
-        assert len(a.options()) == 11
+        assert len(a.options()) == 25
         assert a.options() == list(a.codes.values())
 
 


### PR DESCRIPTION
I tried to combine the strings displayed in the heat pump with the information from the manual. It also seems that the IDs 1, 2 and 4 were incorrect.

ID 24 `LPC` might translate to `limit power consumption`, but I am not sure. It is not mentioned in the manual.

Fixes #185