### PR TITLE
Support Smart-Home-Interface Part 4: Data vector classes

### DIFF
--- a/luxtronik/shi/constants.py
+++ b/luxtronik/shi/constants.py
@@ -11,6 +11,12 @@ LUXTRONIK_DEFAULT_MODBUS_TIMEOUT: Final = 30
 # Default offset for the input or holding indices
 LUXTRONIK_DEFAULT_DEFINITION_OFFSET: Final = 10000
 
+# Identifier of holding data-vectors and partial name for unknown holding fields
+HOLDINGS_FIELD_NAME: Final = "holding"
+
+# Identifier of input data-vectors and partial name for unknown input fields
+INPUTS_FIELD_NAME: Final = "input"
+
 # Waiting time (in seconds) after writing the holdings
 # to give the controller time to recalculate values, etc.
 LUXTRONIK_WAIT_TIME_AFTER_HOLDING_WRITE: Final = 1
@@ -21,3 +27,9 @@ LUXTRONIK_VALUE_FUNCTION_NOT_AVAILABLE: Final = 32767
 
 # First Luxtronik firmware version that supports the Smart Home Interface (SHI)
 LUXTRONIK_FIRST_VERSION_WITH_SHI: Final = (3, 90, 1, 0)
+
+# Latest supported Luxtronik firmware version
+# Note:
+# No checks are performed against this version.
+# This is merely the default value if no version is specified.
+LUXTRONIK_LATEST_SHI_VERSION: Final = (3, 92, 0, 0)

--- a/luxtronik/shi/holdings.py
+++ b/luxtronik/shi/holdings.py
@@ -1,0 +1,24 @@
+"""Parse luxtronik Holdings."""
+
+import logging
+from typing import Final
+
+from luxtronik.definitions.holdings import HOLDINGS_DEFINITIONS_LIST, HOLDINGS_OFFSET
+
+from luxtronik.shi.constants import HOLDINGS_FIELD_NAME
+from luxtronik.shi.definitions import LuxtronikDefinitionsList
+from luxtronik.shi.vector import DataVectorSmartHome
+
+
+HOLDINGS_DEFINITIONS: Final = LuxtronikDefinitionsList(
+    HOLDINGS_DEFINITIONS_LIST,
+    HOLDINGS_FIELD_NAME,
+    HOLDINGS_OFFSET
+)
+
+class Holdings(DataVectorSmartHome):
+    """Class that holds holding fields."""
+
+    logger = logging.getLogger("Luxtronik.Holdings")
+    name = HOLDINGS_FIELD_NAME
+    definitions = HOLDINGS_DEFINITIONS

--- a/luxtronik/shi/inputs.py
+++ b/luxtronik/shi/inputs.py
@@ -1,0 +1,24 @@
+"""Parse luxtronik Inputs."""
+
+import logging
+from typing import Final
+
+from luxtronik.definitions.inputs import INPUTS_DEFINITIONS_LIST, INPUTS_OFFSET
+
+from luxtronik.shi.constants import INPUTS_FIELD_NAME
+from luxtronik.shi.definitions import LuxtronikDefinitionsList
+from luxtronik.shi.vector import DataVectorSmartHome
+
+
+INPUTS_DEFINITIONS: Final = LuxtronikDefinitionsList(
+    INPUTS_DEFINITIONS_LIST,
+    INPUTS_FIELD_NAME,
+    INPUTS_OFFSET
+)
+
+class Inputs(DataVectorSmartHome):
+    """Class that holds input fields."""
+
+    logger = logging.getLogger("Luxtronik.Inputs")
+    name = INPUTS_FIELD_NAME
+    definitions = INPUTS_DEFINITIONS

--- a/luxtronik/shi/vector.py
+++ b/luxtronik/shi/vector.py
@@ -1,0 +1,364 @@
+from luxtronik.data_vector import DataVector
+from luxtronik.datatypes import Base, Unknown
+
+from luxtronik.shi.constants import LUXTRONIK_LATEST_SHI_VERSION
+from luxtronik.shi.common import version_in_range
+from luxtronik.shi.definitions import (
+    integrate_data,
+    LuxtronikDefinition,
+    LuxtronikDefinitionsDictionary,
+)
+
+###############################################################################
+# Smart home interface data-vector
+###############################################################################
+
+class DataVectorSmartHome(DataVector):
+    """
+    Specialized DataVector for Luxtronik Smart Home fields.
+
+    Provides access to fields by name, index or alias.
+    To use aliases, they must first be registered here (locally = only valid
+    for this vector) or directly in the `LuxtronikDefinitionsList`
+    (globally = valid for all newly created vector).
+    """
+
+    # DataVector specific list of definitions as `LuxtronikDefinitionsList`
+    definitions = None # override this
+
+# Field construction methods ##################################################
+
+    @classmethod
+    def create_unknown_field(cls, idx):
+        """
+        Create an unknown field object.
+        Be careful! The used controller firmware
+        may not support this field.
+
+        Args:
+            idx (int): Register index.
+
+        Returns:
+            Unknown: A field instance of type 'Unknown'.
+        """
+        return Unknown(f"unknown_{cls.name}_{idx}", False)
+
+    @classmethod
+    def create_any_field(cls, name_or_idx):
+        """
+        Create a field object from an available definition
+        (= included in class variable `cls.definitions`).
+        Be careful! The used controller firmware
+        may not support this field.
+
+        Args:
+            name_or_idx (str | int): Field name or register index.
+
+        Returns:
+            Base | None: The created field, or None if not found or not valid.
+        """
+        # The definitions object hold all available definitions
+        definition = cls.definitions.get(name_or_idx)
+        if definition is not None and definition.valid:
+            return definition.create_field()
+        return None
+
+    def create_field(self, name_or_idx):
+        """
+        Create a field object from a version-dependent definition (= included in
+        class variable `cls.definitions` and is valid for `self.version`).
+
+        Args:
+            name_or_idx (str | int): Field name or register index.
+
+        Returns:
+            Base | None: The created field, or None if not found or not valid.
+        """
+        definition, _ = self._get_definition(name_or_idx, False)
+        if definition is not None and definition.valid:
+            return definition.create_field()
+        return None
+
+
+# Constructors and magic methods ##############################################
+
+    def _init_instance(self, version, safe):
+        """Re-usable method to initialize all instance variables."""
+        self.safe = safe
+        self._version = version
+
+        # There may be several names or alias that points to one definition.
+        # So in order to spare memory we split the name/index-to-field-lookup
+        # into a name/index-to-definition-lookup and a definition-to-field-lookup
+        self._def_lookup = LuxtronikDefinitionsDictionary()
+        self._field_lookup = {}
+        # Furthermore stores the definition-to-field-lookup separate from the
+        # field-definition pairs to keep the index-sorted order when adding new entries
+        self._items = [] # list of tuples, 0: definition, 1: field
+
+    def __init__(self, version=LUXTRONIK_LATEST_SHI_VERSION, safe=True):
+        """
+        Initialize the data-vector instance.
+
+        Creates field objects for all version-dependent definitions (= included
+        in class variable `cls.definitions` and is valid for `self.version`)
+        and stores them in the data vector.
+
+        Args:
+            version (tuple[int] | None):
+                Version to be used for creating the field objects.
+                This ensures that the data vector only contain valid fields.
+                If None is passed, all available fields are added.
+                (default: LUXTRONIK_LATEST_SHI_VERSION)
+            safe (bool): If false, prevent fields marked as
+                not secure from being written to.
+        """
+        self._init_instance(version, safe)
+
+        # Create fields depending on the given version
+        for d in self.definitions:
+            if version_in_range(version, d.since, d.until):
+                # The definitions are already sorted correctly.
+                # So we can just add them one after the other.
+                self._add(d, d.create_field())
+
+    @classmethod
+    def empty(cls, version=LUXTRONIK_LATEST_SHI_VERSION, safe=True):
+        """
+        Initialize the data-vector instance without any fields.
+
+        Args:
+            version (tuple[int] | None):
+                Version to be used for creating the field objects afterwards.
+                This ensures that the data vector only contain valid fields.
+                If None is passed, all available fields can be added.
+                (default: LUXTRONIK_LATEST_SHI_VERSION)
+            safe (bool): If false, prevent fields marked as
+                not secure from being written to.
+        """
+        obj = cls.__new__(cls) # this don't call __init__()
+        obj._init_instance(version, safe)
+        return obj
+
+    def __getitem__(self, def_name_or_idx):
+        return self.get(def_name_or_idx)
+
+    def __setitem__(self, def_name_or_idx, value):
+        return self.set(def_name_or_idx, value)
+
+    def __len__(self):
+        return len(self._items)
+
+    def __iter__(self):
+        # _items is a list of tuples, 0: definition, 1: field
+        return iter([item[0] for item in self._items])
+
+    def __contains__(self, def_field_name_or_idx):
+        """
+        Check whether the data vector contains a name, index,
+        or definition matching an added field, or the field itself.
+
+        Args:
+            def_field_name_or_idx (LuxtronikDefinition | Base | str | int):
+                Definition object, field object, field name or register index.
+
+        Returns:
+            True if the searched element was found, otherwise False.
+        """
+        if isinstance(def_field_name_or_idx, Base):
+            return any(def_field_name_or_idx is field for field in self._field_lookup.values())
+        elif isinstance(def_field_name_or_idx, LuxtronikDefinition):
+            # speed-up the look-up by search only the name-dict
+            return def_field_name_or_idx.name in self._def_lookup._name_dict
+        else:
+            return def_field_name_or_idx in self._def_lookup
+
+
+# properties and access methods ###############################################
+
+    @property
+    def version(self):
+        return self._version
+
+    def values(self):
+        # _items is a list of tuples, 0: definition, 1: field
+        return iter([item[1] for item in self._items])
+
+    def items(self):
+        """
+        Iterator for all definition-field-pairs (list of tuples with
+        0: definition, 1: field) contained herein."""
+        return iter(self._items)
+
+
+# Find, add and alias methods #################################################
+
+    def _get_definition(self, def_field_name_or_idx, all_not_version_dependent):
+        """
+        Look-up a definition by name, index, a field instance or by the definition itself.
+
+        Args:
+            def_field_name_or_idx (LuxtronikDefinition | Base | str | int):
+                Definition object, field object, field name or register index.
+            all_not_version_dependent (bool): If true, look up the definition
+                within the `cls.definitions` otherwise within `self._def_lookup` (which
+                contain all definitions related to all added fields)
+
+        Returns:
+            tuple[LuxtronikDefinition | None, Base | None]:
+                A definition-field-pair tuple:
+                Index 0: Return the found or given definitions, otherwise None
+                Index 1: Return the given field, otherwise None
+        """
+        definition = def_field_name_or_idx
+        field = None
+        if isinstance(def_field_name_or_idx, Base):
+            definition = def_field_name_or_idx.name
+            field = def_field_name_or_idx
+        if not isinstance(def_field_name_or_idx, LuxtronikDefinition):
+            if all_not_version_dependent:
+                definition = self.definitions.get(definition)
+            else:
+                # def_lookup contains only valid and addable definitions
+                definition = self._def_lookup.get(definition)
+        return definition, field
+
+    def _add(self, definition, field, alias=None):
+        """
+        Add a definition-field-pair to the internal dictionaries.
+
+        Args:
+            definition (LuxtronikDefinition): Definition related to the field.
+            field (Base): Field to add.
+            alias (Hashable | None): Alias, which can be used to access the field again.
+        """
+        self._def_lookup.add(definition, alias)
+        self._field_lookup[definition] = field
+        self._items.append((definition, field))
+
+    def add(self, def_field_name_or_idx, alias=None):
+        """
+        Adds an additional version-dependent field (= included in class variable
+        `cls.definitions` and is valid for `self.version`) to this data vector.
+        Mainly used for data vectors created via `empty()`
+        to read/write individual fields. Existing fields will not be overwritten.
+
+        Args:
+            def_field_name_or_idx (LuxtronikDefinition | Base | str | int):
+                Field to add. Either by definition, name or index, or the field itself.
+            alias (Hashable | None): Alias, which can be used to access the field again.
+
+        Returns:
+            Base | None: The added field object if this could be added or
+                the existing field, otherwise None. In case a field
+
+        Note:
+            It is not possible to add fields which are not defined.
+            To add custom fields, add them to the used `LuxtronikDefinitionsList`
+            (`cls.definitions`) first.
+            If multiple fields added for the same index/name, the last added takes precedence.
+        """
+        # Look-up the related definition
+        definition, field = self._get_definition(def_field_name_or_idx, True)
+        if definition is None:
+            return None
+
+        # Check if the field already exists
+        existing_field = self._field_lookup.get(definition, None)
+        if existing_field is not None:
+            return existing_field
+
+        # Add a (new) field
+        if version_in_range(self._version, definition.since, definition.until):
+            if field is None:
+                field = definition.create_field()
+            self._add(definition, field, alias)
+            # sort _items by definition.index
+            # _items is a list of tuples, 0: definition, 1: field
+            self._items.sort(key=lambda item: item[0].index)
+            return field
+        return None
+
+    def register_alias(self, def_field_name_or_idx, alias):
+        """
+        Add an alternative name (or anything hashable else)
+        that can be used to access a specific field.
+
+        Args:
+            def_field_name_or_idx (LuxtronikDefinition | Base | str | int):
+                Field to which the alias is to be added.
+                Either by definition, name, register index, or the field itself.
+            alias (Hashable): Alias, which can be used to access the field again.
+
+        Returns:
+            Base | None: The field to which the alias was added,
+                or None if not possible
+        """
+        # Resolve a field input
+        def_name_or_idx = def_field_name_or_idx
+        if isinstance(def_name_or_idx, Base):
+            def_name_or_idx = def_name_or_idx.name
+        # register alias
+        definition = self._def_lookup.register_alias(def_name_or_idx, alias)
+        if definition is None:
+            return None
+        return self._field_lookup.get(definition, None)
+
+
+# Data and access methods #####################################################
+
+    def parse(self, raw_data):
+        """
+        Parse raw data into the corresponding fields.
+
+        Args:
+            raw_data (list[int]): List of raw register values.
+                The raw data must start at register index 0.
+        """
+        raw_len = len(raw_data)
+        for definition, field in self._items:
+            if definition.index + definition.count >= raw_len:
+                continue
+            integrate_data(definition, field, raw_data)
+
+    def get(self, def_name_or_idx, default=None):
+        """
+        Retrieve a field by definition, name or register index.
+
+        Args:
+            def_name_or_idx (LuxtronikDefinition | str | int):
+                Definition, name, or register index to be used to search for the field.
+
+        Returns:
+            Base | None: The field found or the provided default if not found.
+
+        Note:
+            If multiple fields added for the same index/name,
+            the last added takes precedence.
+        """
+        if isinstance(def_name_or_idx, LuxtronikDefinition):
+            definition = def_name_or_idx
+        else:
+            definition = self._def_lookup.get(def_name_or_idx)
+        if definition is not None:
+            return self._field_lookup.get(definition, default)
+        return default
+
+    def set(self, def_field_name_or_idx, value):
+        """
+        Set field to new value.
+
+        The value is set, even if the field marked as non-writeable.
+        No data validation is performed either.
+
+        Args:
+            def_field_name_or_idx (LuxtronikDefinition | Base | int | str):
+                Definition, name, or register index to be used to search for the field.
+                It is also possible to pass the field itself.
+            value (int | List[int]): Value to set
+        """
+        field = def_field_name_or_idx
+        if not isinstance(field, Base):
+            field = self.get(def_field_name_or_idx)
+        if field is not None:
+            field.value = value

--- a/tests/shi/test_definitions.py
+++ b/tests/shi/test_definitions.py
@@ -331,6 +331,9 @@ class TestDefinitionsList:
         assert len(definitions) == 4
         assert definitions.name == 'foo'
         assert definitions.offset == 100
+        assert 5 in definitions
+        assert 'field_9a' in definitions
+        assert definitions[7] in definitions
 
         # correct fields
         assert definitions[5].name == "field_5"

--- a/tests/shi/test_vector.py
+++ b/tests/shi/test_vector.py
@@ -1,0 +1,379 @@
+
+from luxtronik.datatypes import Base, Unknown
+from luxtronik.shi.common import parse_version
+from luxtronik.shi.vector import DataVectorSmartHome
+from luxtronik.shi.definitions import LuxtronikDefinitionsList
+
+
+###############################################################################
+# Tests
+###############################################################################
+
+def_list = [
+    {
+        "index": 5,
+        "count": 1,
+        "names": ["field_5"],
+        "type": Base,
+        "writeable": False,
+        "since": "1.1",
+        "until": "1.2",
+    },
+    {
+        "index": 7,
+        "count": 2,
+        "names": ["field_7"],
+        "type": Base,
+        "writeable": True,
+        "since": "3.1",
+    },
+    {
+        "index": 9,
+        "count": 1,
+        "names": ["field_9a"],
+        "type": Base,
+        "writeable": True,
+        "until": "1.3",
+    },
+    {
+        "index": 9,
+        "count": 2,
+        "names": ["field_9"],
+        "type": Base,
+        "writeable": True,
+        "until": "3.3",
+    },
+    {
+        "index": -1,
+        "count": 1,
+        "names": ["field_invalid"],
+        "type": Base,
+        "writeable": True,
+        "until": "3.3",
+    },
+]
+TEST_DEFINITIONS = LuxtronikDefinitionsList(def_list, 'foo', 100)
+
+class DataVectorTest(DataVectorSmartHome):
+    name = 'foo'
+    definitions = TEST_DEFINITIONS
+
+class TestDataVector:
+
+    def test_create(self):
+        # create unknown field
+        field = DataVectorTest.create_unknown_field(10)
+        assert field.name == 'unknown_foo_10'
+        assert not field.writeable
+        assert type(field) is Unknown
+
+        # create invalid field (not available)
+        field = DataVectorTest.create_any_field('field_invalid')
+        assert field is None
+
+        # create available field
+        field = DataVectorTest.create_any_field(7)
+        assert field.name == 'field_7'
+        assert field.writeable
+        assert type(field) is Base
+
+        # create not available field
+        field = DataVectorTest.create_any_field('BAR')
+        assert field is None
+
+        # create versioned data vector
+        data_vector = DataVectorTest(parse_version("1.2"))
+        assert data_vector.version == (1, 2, 0, 0)
+        assert len(data_vector) == 3
+
+        # create version-dependent field
+        field = data_vector.create_field(5)
+        assert field.name == 'field_5'
+        assert not field.writeable
+        assert type(field) is Base
+
+        # create not available field (not available)
+        field = data_vector.create_field(6)
+        assert field is None
+
+        # create not available field (version invalid)
+        field = data_vector.create_field(7)
+        assert field is None
+
+        # create another version-dependent field
+        field = data_vector.create_field(9)
+        assert field.name == 'field_9'
+        assert field.writeable
+        assert type(field) is Base
+
+        # create index-overloaded version-dependent field
+        field = data_vector.create_field('field_9a')
+        assert field.name == 'field_9a'
+        assert field.writeable
+        assert type(field) is Base
+
+        # create versioned data vector
+        data_vector = DataVectorTest(parse_version("3.0"))
+        assert data_vector.version == (3, 0, 0, 0)
+        assert len(data_vector) == 1
+
+        # create not available field (invalid version)
+        field = data_vector.create_field(5)
+        assert field is None
+
+        # create not available field (not available)
+        field = data_vector.create_field(6)
+        assert field is None
+
+        # create not available field (invalid version)
+        field = data_vector.create_field(7)
+        assert field is None
+
+        # create version-dependent field
+        field = data_vector.create_field(9)
+        assert field.name == 'field_9'
+        assert field.writeable
+        assert type(field) is Base
+
+        # create invalid field (not available)
+        field = data_vector.create_field('field_invalid')
+        assert field is None
+
+        # create empty data vector
+        data_vector = DataVectorTest.empty(parse_version("3.0"))
+        assert data_vector.version == (3, 0, 0, 0)
+        assert len(data_vector) == 0
+
+        # create not available field (not available)
+        field = data_vector.create_field(9)
+        assert field is None
+
+    def test_add(self):
+        data_vector = DataVectorTest.empty(parse_version("1.1.2"))
+        assert len(data_vector) == 0
+
+        # Add available index
+        field = data_vector.add(5)
+        assert len(data_vector) == 1
+        assert 5 in data_vector
+        assert field.name == 'field_5'
+
+        # Add not available index (not existing)
+        field = data_vector.add(6)
+        assert 'field_6' not in data_vector
+        assert field is None
+        assert len(data_vector) == 1
+
+        # Add not available index (invalid version)
+        field = data_vector.add(7)
+        assert 7 not in data_vector
+        assert field is None
+        assert len(data_vector) == 1
+
+        # Re-add available index
+        field = data_vector.add(5)
+        assert len(data_vector) == 1
+        assert field.name == 'field_5'
+
+        # Add available field
+        field_9 = Base('field_9', False)
+        field = data_vector.add(field_9)
+        assert 9 in data_vector
+        assert len(data_vector) == 2
+        assert field == field_9
+
+        # Re-add available field
+        field = data_vector.add(field_9)
+        assert field_9 in data_vector
+        assert len(data_vector) == 2
+        assert field == field_9
+
+        # Add available field with same name
+        field_9_2 = Base('field_9', False)
+        field = data_vector.add(field_9_2)
+        assert field_9_2 not in data_vector
+        assert len(data_vector) == 2
+        assert field is field_9
+
+        # Add available definition
+        def_9a = data_vector.definitions['field_9a']
+        field = data_vector.add(def_9a)
+        assert def_9a in data_vector
+        assert len(data_vector) == 3
+        assert field.name == 'field_9a'
+
+        # Get via index (last added)
+        field = data_vector.get(9)
+        assert field.name == 'field_9a'
+
+        # Get via name
+        field = data_vector.get('field_9')
+        assert field == field_9
+
+        # Get via definition
+        field = data_vector.get(def_9a)
+        assert field.name == 'field_9a'
+
+        # Get via None
+        field = data_vector.get(None)
+        assert field is None
+
+        # Get via invalid name
+        field = data_vector.get('field_10')
+        assert field is None
+
+        # Get via invalid index
+        field = data_vector.get(2)
+        assert field is None
+
+    def test_iter(self):
+        data_vector = DataVectorTest.empty(parse_version("1.1.2"))
+        data_vector.add('field_9a')
+        data_vector.add(5)
+        data_vector.add(9)
+
+        for index, definition in enumerate(data_vector):
+            if index == 0:
+                assert definition.index == 5
+                assert definition.name == 'field_5'
+            if index == 1:
+                assert definition.index == 9
+                assert definition.name == 'field_9a'
+            if index == 2:
+                assert definition.index == 9
+                assert definition.name == 'field_9'
+
+        for index, field in enumerate(data_vector.values()):
+            if index == 0:
+                assert field.name == 'field_5'
+            if index == 1:
+                assert field.name == 'field_9a'
+            if index == 2:
+                assert field.name == 'field_9'
+
+        for index, (definition, field) in enumerate(data_vector.items()):
+            if index == 0:
+                assert definition.index == 5
+                assert definition.name == 'field_5'
+                assert field.name == 'field_5'
+            if index == 1:
+                assert definition.index == 9
+                assert definition.name == 'field_9a'
+                assert field.name == 'field_9a'
+            if index == 2:
+                assert definition.index == 9
+                assert definition.name == 'field_9'
+                assert field.name == 'field_9'
+
+    def test_set(self):
+        data_vector = DataVectorTest(parse_version("1.1.2"))
+        field_5 = data_vector[5]
+        field_9 = data_vector[9]
+
+        # set via property (writeable)
+        data_vector['field_9'] = [2, 8]
+        assert field_5.value is None
+        assert field_9.value == [2, 8]
+
+        # set via method (non-writeable)
+        data_vector.set(5, 1)
+        assert field_5.value == 1
+        assert field_9.value == [2, 8]
+
+        # set via field
+        field_5.value = [4, 3]
+        field_9.value = 6
+        assert field_5.value == [4, 3]
+        assert field_9.value == 6
+
+    def test_parse(self):
+        data_vector = DataVectorTest(parse_version("1.1.2"))
+        field_5 = data_vector[5]
+        field_9 = data_vector[9]
+        field_9a = data_vector['field_9a']
+
+        # not enough data
+        data = [1]
+        data_vector.parse(data)
+        assert field_5.value is None
+        assert field_9.value is None
+        assert field_9a.value is None
+
+        # data only for field 5
+        data = [1, 2, 3, 4, 5, 6, 7]
+        data_vector.parse(data)
+        assert field_5.value == 6
+        assert field_9.value is None
+        assert field_9a.value is None
+
+        # data for all fields
+        data = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2]
+        data_vector.parse(data)
+        assert field_5.value == 4
+        assert field_9.value == [0, -1]
+        assert field_9a.value == 0
+
+    def test_alias(self):
+        TEST_DEFINITIONS.register_alias('field_9a', 10)
+        data_vector = DataVectorTest(parse_version("1.1.2"))
+
+        # global alias
+        def_9a = TEST_DEFINITIONS[10]
+        field_9a = data_vector[10]
+        assert def_9a is not None
+        assert field_9a is not None
+        assert field_9a.name == 'field_9a'
+
+        # local alias
+        data_vector.register_alias(5, 6)
+        def_5 = TEST_DEFINITIONS[6]
+        field_5 = data_vector[6]
+        assert def_5 is None
+        assert field_5 is not None
+        assert field_5.name == 'field_5'
+
+        # alias of alias
+        data_vector.register_alias(6, 7)
+        field_5 = data_vector[7]
+        assert field_5 is not None
+        assert field_5.name == 'field_5'
+
+        # alias of field
+        data_vector.register_alias(field_9a, 11)
+        field_9a = data_vector[11]
+        assert field_9a is not None
+        assert field_9a.name == 'field_9a'
+
+        # alias of field
+        field = data_vector.register_alias(2, 7)
+        assert field is None
+
+        # alias 7 still valid
+        field_5 = data_vector[7]
+        assert field_5 is not None
+        assert field_5.name == 'field_5'
+
+    def test_global_alias(self):
+        data_vector = DataVectorTest(parse_version("1.1.2"))
+
+        # persistent alias
+        def_9a = TEST_DEFINITIONS[10]
+        field_9a = data_vector[10]
+        assert def_9a is not None
+        assert field_9a is not None
+        assert field_9a.name == 'field_9a'
+
+    def test_version_none(self):
+        data_vector = DataVectorTest.empty(None)
+        assert len(data_vector) == 0
+
+        data_vector.add(5)
+        assert len(data_vector) == 1
+        data_vector.add(7)
+        assert len(data_vector) == 2
+        data_vector.add(9)
+        assert len(data_vector) == 3
+        data_vector.add("field_invalid")
+        assert len(data_vector) == 3
+        data_vector.add(10) # field_9a alias
+        assert len(data_vector) == 4


### PR DESCRIPTION
Fourth pull request to gradually integrate the smart home interface. This pull request includes:

DataVectorSmartHome: Base class for all SHI data vectors
Specialized data vectors for Inputs and Holdings
Pytest units for new methods and classes

Part 4 for #190