### PR TITLE
Add new fields for shi of luxtronik v3.92.1

### DIFF
--- a/luxtronik/definitions/holdings.py
+++ b/luxtronik/definitions/holdings.py
@@ -17,6 +17,7 @@ from luxtronik.datatypes import (
     LpcMode,
     OnOffMode,
     PowerLimit,
+    Unknown,
 )
 
 # Offset which must be added to the holding indices
@@ -376,6 +377,15 @@ HOLDINGS_DEFINITIONS_LIST: Final = [
         "writeable": True,
         "since": "3.90.1",
         "description": "Lock state for the swimming pool function",
+    },
+    {
+        "index": 60,
+        "count": 1,
+        "names": ["unknown_holding_60"],
+        "type": Unknown,
+        "writeable": False,
+        "since": "3.92.1",
+        "description": "TODO: Function unknown – requires further analysis",
     },
     {
         "index": 65,

--- a/luxtronik/shi/constants.py
+++ b/luxtronik/shi/constants.py
@@ -32,4 +32,4 @@ LUXTRONIK_FIRST_VERSION_WITH_SHI: Final = (3, 90, 1, 0)
 # Note:
 # No checks are performed against this version.
 # This is merely the default value if no version is specified.
-LUXTRONIK_LATEST_SHI_VERSION: Final = (3, 92, 0, 0)
+LUXTRONIK_LATEST_SHI_VERSION: Final = (3, 92, 1, 0)


### PR DESCRIPTION
With v3.92.1 a holding field whose function is still unknown has been added.

Update for #190