### PR TITLE
Return "Unknown_{value}" for not supported selections

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -134,6 +134,8 @@ class SelectionBase(Base):
 
     datatype_class = "selection"
 
+    unknown_prefix = "Unknown"
+    unknown_delimiter = "_"
     codes = {}
 
     @classmethod
@@ -145,13 +147,15 @@ class SelectionBase(Base):
     def from_heatpump(cls, value):
         if value in cls.codes:
             return cls.codes.get(value)
-        return None
+        return f"{cls.unknown_prefix}{cls.unknown_delimiter}{value}"
 
     @classmethod
     def to_heatpump(cls, value):
         for index, code in cls.codes.items():
             if code == value:
                 return index
+        if value.startswith(cls.unknown_prefix):
+            return int(value.split(cls.unknown_delimiter)[1])
         return None
 
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -223,13 +223,14 @@ class TestSelectionBase:
         """Test cases for from_heatpump function"""
 
         a = SelectionBase("")
-        assert a.from_heatpump(0) is None
+        assert a.from_heatpump(0) == 'Unknown_0'
 
     def test_to_heatpump(self):
         """Test cases for to_heatpump function"""
 
         a = SelectionBase("")
         assert a.to_heatpump("a") is None
+        assert a.to_heatpump("Unknown_214") == 214
 
 
 class SelectionBaseChild(SelectionBase):
@@ -267,7 +268,7 @@ class TestSelectionBaseChild:
         assert a.from_heatpump(0) == "a"
         assert a.from_heatpump(1) == "b"
         assert a.from_heatpump(2) == "c"
-        assert a.from_heatpump(3) is None
+        assert a.from_heatpump(3) == "Unknown_3"
 
     def test_to_heatpump(self):
         """Test cases for to_heatpump function"""


### PR DESCRIPTION
In my opinion, there is no reason to return `None` for unknown values.

Fixes #197 